### PR TITLE
chore: Update CI deps and fix golangci-lint for Go 1.25

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          install-mode: goinstall

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           cache: true
       - name: Test
         run: go test ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Upgraded Go version to 1.25.x across all GitHub Actions workflows (`test.yml`, `goreleaser.yml`, `golangci-lint.yml`). Removed the explicit `version: latest` configuration from `golangci-lint-action` and added `install-mode: goinstall` to resolve the `can't load config` mismatch error caused by the targeted Go 1.25 version being newer than the pre-compiled linter's Go 1.24 version.

---
*PR created automatically by Jules for task [15968331309128215900](https://jules.google.com/task/15968331309128215900) started by @arran4*