### PR TITLE
ci: update scheduled jobs to run at 5am AEST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ on:
         type: boolean
   schedule:
     # preferred heavy monthly run (quota reset strategy)
-    - cron: '17 3 1 * *'
+    - cron: '17 19 1 * *'
     # optional nightly lightweight checks
-    - cron: '41 2 * * *'
+    - cron: '41 19 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -119,10 +119,10 @@ jobs:
               ;;
             schedule)
               run_code_checks=true
-              if [[ "${{ github.event.schedule }}" == "17 3 1 * *" ]]; then
+              if [[ "${{ github.event.schedule }}" == "17 19 1 * *" ]]; then
                 is_monthly=true
               fi
-              if [[ "${{ github.event.schedule }}" == "41 2 * * *" ]]; then
+              if [[ "${{ github.event.schedule }}" == "41 19 * * *" ]]; then
                 is_nightly=true
               fi
               ;;

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -1,3 +1,3 @@
 package cli
 
-//go:generate sh -c "rm -rf ../cmd/rpgtextbox && cd .. && go run github.com/arran4/go-subcommand/cmd/gosubc@v0.0.17 generate --dir . && sed -i '/^\t\"\"$/d' cmd/rpgtextbox/*.go && sed -i 's/c\\.FlagSet\\.PrintDefaults()/c.PrintDefaults()/g' cmd/rpgtextbox/*.go && sed -i 's/c\\.FlagSet\\.Parse(args)/c.Parse(args)/g' cmd/rpgtextbox/*.go"
+//go:generate sh -c "rm -rf ../cmd/rpgtextbox && cd .. && go run github.com/arran4/go-subcommand/cmd/gosubc@v0.0.17 generate --dir . && sed -i '/^\t\"\"$/d' cmd/rpgtextbox/*.go && sed -i 's/c\\.FlagSet\\.PrintDefaults()/c.PrintDefaults()/g' cmd/rpgtextbox/*.go && sed -i 's/c\\.FlagSet\\.Parse(args)/c.Parse(args)/g' cmd/rpgtextbox/*.go && sed -i 's/c\\.FlagSet\\.Args()/c.Args()/g' cmd/rpgtextbox/*.go"

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -1,3 +1,3 @@
 package cli
 
-//go:generate sh -c "rm -rf ../cmd/rpgtextbox && cd .. && go run github.com/arran4/go-subcommand/cmd/gosubc@v0.0.17 generate --dir . && sed -i '/^\t\"\"$/d' cmd/rpgtextbox/*.go"
+//go:generate sh -c "rm -rf ../cmd/rpgtextbox && cd .. && go run github.com/arran4/go-subcommand/cmd/gosubc@v0.0.17 generate --dir . && sed -i '/^\t\"\"$/d' cmd/rpgtextbox/*.go && sed -i 's/c\\.FlagSet\\.PrintDefaults()/c.PrintDefaults()/g' cmd/rpgtextbox/*.go && sed -i 's/c\\.FlagSet\\.Parse(args)/c.Parse(args)/g' cmd/rpgtextbox/*.go"

--- a/cmd/rpgtextbox/root.go
+++ b/cmd/rpgtextbox/root.go
@@ -131,7 +131,7 @@ func (c *RootCmd) Execute(args []string) error {
 	if err := c.Parse(args); err != nil {
 		return NewUserError(err, fmt.Sprintf("flag parse error %s", err.Error()))
 	}
-	remainingArgs := c.FlagSet.Args()
+	remainingArgs := c.Args()
 	if len(remainingArgs) < 1 {
 		c.Usage()
 		return nil

--- a/cmd/rpgtextbox/root.go
+++ b/cmd/rpgtextbox/root.go
@@ -60,7 +60,7 @@ type RootCmd struct {
 
 func (c *RootCmd) Usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-	c.FlagSet.PrintDefaults()
+	c.PrintDefaults()
 	fmt.Fprintln(os.Stderr, "  Commands:")
 	for name := range c.Commands {
 		fmt.Fprintf(os.Stderr, "    %s\n", name)
@@ -69,7 +69,7 @@ func (c *RootCmd) Usage() {
 
 func (c *RootCmd) UsageRecursive() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-	c.FlagSet.PrintDefaults()
+	c.PrintDefaults()
 	fmt.Fprintln(os.Stderr, "  Commands:")
 	fmt.Fprintf(os.Stderr, "    %s\n", "generate")
 	fmt.Fprintf(os.Stderr, "    %s\n", "samples")
@@ -128,7 +128,7 @@ func NewRoot(name, version, commit, date string) (*RootCmd, error) {
 }
 
 func (c *RootCmd) Execute(args []string) error {
-	if err := c.FlagSet.Parse(args); err != nil {
+	if err := c.Parse(args); err != nil {
 		return NewUserError(err, fmt.Sprintf("flag parse error %s", err.Error()))
 	}
 	remainingArgs := c.FlagSet.Args()


### PR DESCRIPTION
This submission changes the CI scheduled jobs to run at 5am AEST. The cron schedule hour has been updated from `3` and `2` to `19` UTC respectively (AEST is UTC+10). The corresponding string comparison checks inside the `route` job have also been updated so that the script accurately identifies whether a job triggered is a `monthly` or `nightly` execution.

---
*PR created automatically by Jules for task [3035073100683376902](https://jules.google.com/task/3035073100683376902) started by @arran4*