### PR TITLE
docs: update license section in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -291,7 +291,7 @@ rpgtextbox generate \
 
 # License 
 
-TBH I really haven't thought about it. Contact me
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## AI Agent Skills
 


### PR DESCRIPTION
Updates the license text in `readme.md` to properly reference the MIT License and the `LICENSE` file instead of the informal placeholder text.

---
*PR created automatically by Jules for task [14981288500737394296](https://jules.google.com/task/14981288500737394296) started by @arran4*